### PR TITLE
Allow to fill model in addiction to array.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 /build/
+/.idea/

--- a/src/Eloquent/Concerns/HasFillableRelations.php
+++ b/src/Eloquent/Concerns/HasFillableRelations.php
@@ -100,9 +100,9 @@ trait HasFillableRelations
 
     /**
      * @param BelongsTo $relation
-     * @param array $attributes
+     * @param array|Model $attributes
      */
-    public function fillBelongsToRelation(BelongsTo $relation, array $attributes)
+    public function fillBelongsToRelation(BelongsTo $relation, $attributes)
     {
         $entity = $attributes;
         if (!$attributes instanceof Model) {
@@ -115,9 +115,9 @@ trait HasFillableRelations
 
     /**
      * @param HasOne $relation
-     * @param array $attributes
+     * @param array|Model $attributes
      */
-    public function fillHasOneRelation(HasOne $relation, array $attributes)
+    public function fillHasOneRelation(HasOne $relation, $attributes)
     {
         $related = $attributes;
         if (!$attributes instanceof Model) {


### PR DESCRIPTION
When I tried to fill a model, I get a PHP error saying `fillBelongsToRelation` expects as second parameter an array, object passed.

Seeing the code, I found the method sign force the second parameter be an array, but in method body checks if is a Model.

I propose to change method signature without type-hinting as array the second parameter, and specify in PHPDoc that the second parameter can be array or Model.