### PR TITLE
Update illuminate/database to ^6.0 and updated old dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "~5.3"
+        "illuminate/database": "~6.0"
     },
     "autoload": {
         "psr-4": {
@@ -18,10 +18,10 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
-        "orchestra/database": "~3.5",
-        "orchestra/testbench": "^3.5",
-        "mockery/mockery": "^0.9.4"
+        "phpunit/phpunit": "^8.3",
+        "orchestra/database": "^4.0",
+        "orchestra/testbench": "^4.0",
+        "mockery/mockery": "^1.2.3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,7 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	processIsolation="false"
-	stopOnFailure="true"
-	syntaxCheck="false">
+	stopOnFailure="true">
   <testsuites>
 	<testsuite name="Fillable Relations Test Suite">
 	  <directory suffix=".php">./tests/</directory>

--- a/src/Eloquent/Concerns/HasFillableRelations.php
+++ b/src/Eloquent/Concerns/HasFillableRelations.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use RuntimeException;
 use ReflectionObject;
 
@@ -54,7 +56,7 @@ trait HasFillableRelations
         $relationsAttributes = [];
 
         foreach ($this->fillableRelations() as $relationName) {
-            $val = array_pull($attributes, $relationName);
+            $val = Arr::pull($attributes, $relationName);
             if ($val !== null) {
                 $relationsAttributes[$relationName] = $val;
             }
@@ -66,7 +68,7 @@ trait HasFillableRelations
     public function fillRelations(array $relations)
     {
         foreach ($relations as $relationName => $attributes) {
-            $relation = $this->{camel_case($relationName)}();
+            $relation = $this->{Str::camel($relationName)}();
 
             $relationType = (new ReflectionObject($relation))->getShortName();
             $method = "fill{$relationType}Relation";
@@ -140,7 +142,7 @@ trait HasFillableRelations
     {
         if (!$this->exists) {
             $this->save();
-            $relation = $this->{camel_case($relationName)}();
+            $relation = $this->{Str::camel($relationName)}();
         }
 
         $relation->delete();
@@ -169,7 +171,7 @@ trait HasFillableRelations
     {
         if (!$this->exists) {
             $this->save();
-            $relation = $this->{camel_case($relationName)}();
+            $relation = $this->{Str::camel($relationName)}();
         }
 
         $relation->detach();
@@ -211,7 +213,7 @@ trait HasFillableRelations
     {
         if (!$this->exists) {
             $this->save();
-            $relation = $this->{camel_case($relationName)}();
+            $relation = $this->{Str::camel($relationName)}();
         }
 
         $relation->delete();

--- a/tests/DetachTest.php
+++ b/tests/DetachTest.php
@@ -9,7 +9,7 @@ class DetachTests extends TestCase
 {
     protected $vehicle;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 abstract class TestCase extends Orchestra
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->artisan('migrate', ['--database' => 'testbench']);


### PR DESCRIPTION
This PR fixes #21 . I've updated the dependency illuminate/database to ^6.0 and dev dependencies should be updated as orchestra/database and orchestra/testbench had a new version. PHPUnit and mockery had to be updated as well, required not only by new dependencies but they were old and were throwing some warnings to the console as well.

All tests are passing.